### PR TITLE
Added the ability to process files in Config/Input and Update for DCS 2.7.18080

### DIFF
--- a/DCS-Input-Command-Injector-Quaggles/DCS-Input-Command-Injector-Quaggles/Scripts/Input/Data.lua
+++ b/DCS-Input-Command-Injector-Quaggles/DCS-Input-Command-Injector-Quaggles/Scripts/Input/Data.lua
@@ -93,11 +93,14 @@ local function QuagglesInputCommandInjector(filename, folder, env, result)
 	if quagglesLoggingEnabled then log.write(quagglesLogName, log.INFO, 'Detected loading of: '..filename) end
 	-- Only operate on files that are in this folder
 	local targetPrefixForAircrafts = "./Mods/aircraft/"
-	local targetPrefixForConfig = "./Config/Input/"
+	local targetPrefixForDotConfig = "./Config/Input/"
+	local targetPrefixForConfig    = "Config/Input/"
 	local targetPrefix = nil
 	if StartsWith(filename, targetPrefixForAircrafts) and StartsWith(folder, targetPrefixForAircrafts) then
 		targetPrefix = targetPrefixForAircrafts
-	elseif StartsWith(filename, targetPrefixForConfig) and StartsWith(folder, targetPrefixForConfig) then
+	elseif StartsWith(filename, targetPrefixForDotConfig) and StartsWith(folder, targetPrefixForDotConfig) then
+		targetPrefix = targetPrefixForDotConfig
+	elseif StartsWith(filename, targetPrefixForConfig) then
 		targetPrefix = targetPrefixForConfig
 	end
 	if targetPrefix then
@@ -576,6 +579,14 @@ local default_assignments =
 		roll	= 'JOY_X',
 		thrust	= 'JOY_Z',
 		fire	= 'JOY_BTN14',
+	},
+	["SideWinder Force Feedback 2 Joystick"] = 
+	{ 
+		thrust	= 'JOY_SLIDER1',
+		pitch	= 'JOY_Y',
+		roll	= 'JOY_X',
+		rudder	= 'JOY_RZ',
+		fire	= 'JOY_BTN1',
 	},
 }
 

--- a/Inject.lua
+++ b/Inject.lua
@@ -16,11 +16,14 @@ local function QuagglesInputCommandInjector(filename, folder, env, result)
 	if quagglesLoggingEnabled then log.write(quagglesLogName, log.INFO, 'Detected loading of: '..filename) end
 	-- Only operate on files that are in this folder
 	local targetPrefixForAircrafts = "./Mods/aircraft/"
-	local targetPrefixForConfig = "./Config/Input/"
+	local targetPrefixForDotConfig = "./Config/Input/"
+	local targetPrefixForConfig    = "Config/Input/"
 	local targetPrefix = nil
 	if StartsWith(filename, targetPrefixForAircrafts) and StartsWith(folder, targetPrefixForAircrafts) then
 		targetPrefix = targetPrefixForAircrafts
-	elseif StartsWith(filename, targetPrefixForConfig) and StartsWith(folder, targetPrefixForConfig) then
+	elseif StartsWith(filename, targetPrefixForDotConfig) and StartsWith(folder, targetPrefixForDotConfig) then
+		targetPrefix = targetPrefixForDotConfig
+	elseif StartsWith(filename, targetPrefixForConfig) then
 		targetPrefix = targetPrefixForConfig
 	end
 	if targetPrefix then


### PR DESCRIPTION
This allows users to edit the Config/Input/Aircrafts bindings, such as the base and common bindings, which is especially useful to set up general bindings for the lower fidelity modules such as in FC3. Only tested with the Aircrafts subfolder, as apparently it has a differing prefix than the UiLayer despite being in the same directory.
Also included are DCS Update 2.7.8.18080 changes to data, namely the addition of the SideWinder Force Feedback 2 Joystick in the default assignments.